### PR TITLE
Fix persistent learning speech tracking

### DIFF
--- a/src/engine/PersistentLearningEngine.js
+++ b/src/engine/PersistentLearningEngine.js
@@ -348,6 +348,21 @@ export class PersistentLearningEngine {
         // Bu implementation için basit bir değer döndürüyoruz
         return Math.min(1.0, this.metrics.totalInteractions / 100);
     }
+
+    /**
+     * Track bacteria speech for vocabulary statistics
+     */
+    async trackSpeech(bacteria, message) {
+        if (!this.isReady || !message) return;
+
+        try {
+            const words = this.extractWords(message);
+            await this.learnFromWords(words, true, 'speech');
+            this.metrics.totalInteractions++;
+        } catch (error) {
+            console.warn('⚠️ Failed to track speech:', error);
+        }
+    }
     
     /**
      * Metrikleri güncelle


### PR DESCRIPTION
## Summary
- implement `trackSpeech` in `PersistentLearningEngine`

## Testing
- `npm test` *(fails: cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_68534d4c262c8332a6a475578d0d4121