### PR TITLE
Fix Turkish vocabulary parsing

### DIFF
--- a/src/managers/UserInteractionManager.js
+++ b/src/managers/UserInteractionManager.js
@@ -383,7 +383,7 @@ export default class UserInteractionManager {
         if (!bacteria) return;
         
         const words = userMsg.toLowerCase()
-            .replace(/[^\w\s]/g, '')
+            .replace(/[^\wçğıöşüâîû\s]/g, '')
             .split(' ')
             .filter(word => word.length > 2);
         


### PR DESCRIPTION
## Summary
- preserve Turkish characters when updating bacteria vocabulary

## Testing
- `npm test` *(fails: cannot find module /jest)*

------
https://chatgpt.com/codex/tasks/task_e_6853bc485e188332ba28beffe13c054a