### PR TITLE
Refactor model loader with service

### DIFF
--- a/src/engine/TabPFNAdapter.ts
+++ b/src/engine/TabPFNAdapter.ts
@@ -2,10 +2,14 @@
 // TabPFN Adapter - Kelime Analizi ve Öneri Sistemi
 import trainingDataJson from '../data/consciousness_training_data.json' assert { type: 'json' };
 import * as tf from '@tensorflow/tfjs';
+import { ModelService } from '@/services/ModelService.ts';
 
 
 export class TabPFNAdapter {
-    constructor() {
+    private modelService: ModelService;
+
+    constructor(modelService: ModelService) {
+        this.modelService = modelService;
         this.isReady = false;
         this.model = null;
         this.trainingData = [];
@@ -39,7 +43,7 @@ export class TabPFNAdapter {
                 }
 
                 try {
-                    this.model = await tf.loadGraphModel('models/tabpfn/model.json');
+                    this.model = await this.modelService.loadModel();
                 } catch (modelErr) {
                     console.error('❌ GraphModel yüklenemedi:', modelErr);
                     this.model = null;
@@ -279,5 +283,6 @@ export class TabPFNAdapter {
     }
 }
 
-// Global instance
-export const tabPFNAdapter = new TabPFNAdapter(); 
+// Global instance with model service
+const tabPFNModelService = new ModelService('https://cdn.example.com/neomag', 'latest');
+export const tabPFNAdapter = new TabPFNAdapter(tabPFNModelService);

--- a/src/services/ModelService.ts
+++ b/src/services/ModelService.ts
@@ -1,0 +1,47 @@
+import * as tf from '@tensorflow/tfjs';
+
+export class ModelService {
+    private modelUrl: string;
+    private version: string;
+    private cache: Map<string, tf.GraphModel>;
+    private currentVersion: string | null;
+
+    constructor(modelUrl: string, version: string) {
+        this.modelUrl = modelUrl;
+        this.version = version;
+        this.cache = new Map();
+        this.currentVersion = null;
+    }
+
+    setVersion(version: string) {
+        if (this.version !== version) {
+            if (this.currentVersion && this.cache.has(this.currentVersion)) {
+                this.cache.delete(this.currentVersion);
+            }
+            this.version = version;
+        }
+    }
+
+    async loadModel(): Promise<tf.GraphModel> {
+        if (this.currentVersion !== this.version) {
+            if (this.currentVersion && this.cache.has(this.currentVersion)) {
+                this.cache.delete(this.currentVersion);
+            }
+            this.currentVersion = this.version;
+        }
+
+        if (this.cache.has(this.version)) {
+            return this.cache.get(this.version) as tf.GraphModel;
+        }
+
+        const url = `${this.modelUrl}/${this.version}/model.json`;
+        const model = await tf.loadGraphModel(url);
+        this.cache.set(this.version, model);
+        return model;
+    }
+
+    clearCache() {
+        this.cache.clear();
+        this.currentVersion = null;
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `ModelService` that caches TF models per version
- refactor `TabPFNAdapter` to use `ModelService` for loading models from CDN

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6853e231c1108332965a767f5df51c83