### PR TITLE
Add context-aware answer engine modules

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,57 @@
+import { summarize } from '../src/engine/ContextSummarizer.js';
+import { CharacterProfile } from '../src/engine/CharacterProfile.js';
+import { generateAnswer } from '../src/engine/LanguageEngine.js';
+
+const chatHistory = [];
+
+const chatInput = document.getElementById('chatInput');
+const sendBtn = document.getElementById('sendMessageBtn');
+const messagesDiv = document.getElementById('chatMessages');
+const indicator = document.getElementById('chatLoadingIndicator');
+
+function addMessage(sender, text, type) {
+  setTimeout(() => {
+    const div = document.createElement('div');
+    div.className = `chat-message ${type}`;
+    div.innerHTML = `<strong>${sender}:</strong> ${text}`;
+    messagesDiv.appendChild(div);
+    messagesDiv.scrollTop = messagesDiv.scrollHeight;
+  }, 0);
+}
+
+async function onUserMessage() {
+  const msg = chatInput.value.trim();
+  if (!msg) return;
+
+  chatInput.value = '';
+  addMessage('Sen', msg, 'user');
+  chatHistory.push({ sender: 'user', text: msg });
+
+  indicator.classList.remove('hidden');
+  const summary = await summarize(chatHistory);
+  const profile = new CharacterProfile('Bakteri-2', 'curious');
+  const reply = await generateAnswer(msg, summary, profile);
+  indicator.classList.add('hidden');
+
+  chatHistory.push({ sender: 'bacteria', text: reply });
+  addMessage('Bakteri', reply, 'bacteria');
+}
+
+sendBtn?.addEventListener('click', onUserMessage);
+chatInput?.addEventListener('keypress', e => {
+  if (e.key === 'Enter') onUserMessage();
+});
+
+export { summarize, CharacterProfile, generateAnswer };
+
+// Example usage
+// import { summarize } from './engine/ContextSummarizer';
+// import { CharacterProfile } from './engine/CharacterProfile';
+// import { generateAnswer } from './engine/LanguageEngine';
+//
+// async function onUserMessage(userMsg) {
+//   const summary = await summarize(chatHistory);
+//   const profile = new CharacterProfile('Bakteri-2', 'curious');
+//   const reply = await generateAnswer(userMsg, summary, profile);
+//   displayBotReply(reply);
+// }

--- a/src/engine/CharacterProfile.js
+++ b/src/engine/CharacterProfile.js
@@ -1,0 +1,22 @@
+export class CharacterProfile {
+  constructor(id, tone) {
+    this.id = id;
+    this.tone = tone;
+  }
+
+  applyTone(answer) {
+    const phrases = {
+      curious: ['merak ediyorum', 'ilginç değil mi?'],
+      playful: ['haha!', 'çok eğlenceli'],
+      scientific: ['bilimsel olarak', 'araştırmalara göre']
+    }[this.tone] || [];
+
+    const count = 1 + Math.floor(Math.random() * 2);
+    let final = answer;
+    for (let i = 0; i < count; i++) {
+      const phrase = phrases[Math.floor(Math.random() * phrases.length)] || '';
+      final += (phrase ? ' ' + phrase : '');
+    }
+    return final.trim();
+  }
+}

--- a/src/engine/ContextSummarizer.js
+++ b/src/engine/ContextSummarizer.js
@@ -1,0 +1,30 @@
+const CACHE = new Map();
+const WINDOW_SIZE = 5;
+let workerPromise = null;
+
+function loadWorker() {
+  if (!workerPromise) {
+    workerPromise = import(
+      /* webpackChunkName: "summarizer" */ './workers/summarizerWorker.js?worker'
+    ).then(m => new m.default());
+  }
+  return workerPromise;
+}
+
+export async function summarize(messages = []) {
+  const window = messages.slice(-WINDOW_SIZE);
+  const key = JSON.stringify(window);
+  if (CACHE.has(key)) return CACHE.get(key);
+
+  const worker = await loadWorker();
+
+  return new Promise(resolve => {
+    const handle = e => {
+      worker.removeEventListener('message', handle);
+      CACHE.set(key, e.data);
+      resolve(e.data);
+    };
+    worker.addEventListener('message', handle);
+    worker.postMessage(window);
+  });
+}

--- a/src/engine/LanguageEngine.js
+++ b/src/engine/LanguageEngine.js
@@ -1,0 +1,53 @@
+const intentCache = new Map();
+let regexWorker = null;
+
+function getRegexWorker() {
+  if (!regexWorker) {
+    const blob = new Blob([
+      `self.onmessage = e => {\n` +
+      `  const text = (e.data || '').toLowerCase();\n` +
+      `  const result = {};\n` +
+      `  result.intent = /\b(nas\u0131l|neden|what|why|when|how|\?)\b/.test(text) ? 'question' : 'statement';\n` +
+      `  const entities = [];\n` +
+      `  if (/bakteri/.test(text)) entities.push('bacteria');\n` +
+      `  if (/yemek|besin/.test(text)) entities.push('food');\n` +
+      `  result.entities = entities;\n` +
+      `  self.postMessage(result);\n` +
+      `};`
+    ], { type: 'application/javascript' });
+    regexWorker = new Worker(URL.createObjectURL(blob));
+  }
+  return regexWorker;
+}
+
+function extractIntent(text) {
+  const key = text.toLowerCase();
+  if (intentCache.has(key)) return Promise.resolve(intentCache.get(key));
+
+  return new Promise(resolve => {
+    const worker = getRegexWorker();
+    const handler = e => {
+      worker.removeEventListener('message', handler);
+      intentCache.set(key, e.data);
+      resolve(e.data);
+    };
+    worker.addEventListener('message', handler);
+    worker.postMessage(text);
+  });
+}
+
+export async function generateAnswer(userMsg, contextSummary, profile) {
+  const { intent, entities } = await extractIntent(userMsg);
+
+  const acknowledge = intent === 'question'
+    ? 'Sorunu anladım.'
+    : 'Bahsettiğin konu ilgimi çekti.';
+
+  const fact = entities.includes('bacteria')
+    ? `Sohbet geçmişinde öne çıkanlar: ${contextSummary || 'henüz veri yok.'}`
+    : 'Bu konuda daha fazla detay paylaşabilirim.';
+
+  const toneSentence = profile.applyTone('Umarım bu bilgi işine yarar.');
+
+  return [acknowledge, fact, toneSentence].join(' ');
+}

--- a/src/engine/workers/summarizerWorker.js
+++ b/src/engine/workers/summarizerWorker.js
@@ -1,0 +1,28 @@
+self.onmessage = (e) => {
+  const messages = e.data || [];
+  const summary = summarize(messages);
+  self.postMessage(summary);
+};
+
+const stopWords = new Set([
+  'the','a','an','and','ve','ile','için','mi','mı','mu','mü','bir','da','de'
+]);
+
+function summarize(messages) {
+  const freq = Object.create(null);
+  for (const { text } of messages) {
+    const words = (text || '')
+      .toLowerCase()
+      .match(/\p{L}+/gu) || [];
+    for (const w of words) {
+      if (!stopWords.has(w)) freq[w] = (freq[w] || 0) + 1;
+    }
+  }
+  const keywords = Object.entries(freq)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([w]) => w);
+  return keywords.length
+    ? `Öne çıkan kelimeler: ${keywords.join(', ')}`
+    : '';
+}


### PR DESCRIPTION
## Summary
- add a `ContextSummarizer` with worker-based summarization and caching
- implement `CharacterProfile` for tone injection
- create `LanguageEngine` that extracts intents via worker and generates replies
- add a `summarizerWorker` web worker
- provide a small entry point `public/main.js` demonstrating usage

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6853ea69aa2c8332b1dafb39c5acb7ee