### PR TITLE
Implement background simulation and chat upgrades

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1,6 +1,6 @@
-import { summarize } from '../src/engine/ContextSummarizer.js';
-import { CharacterProfile } from '../src/engine/CharacterProfile.js';
-import { generateAnswer } from '../src/engine/LanguageEngine.js';
+let summarize;
+let CharacterProfile;
+let generateAnswer;
 
 const chatHistory = [];
 
@@ -8,6 +8,18 @@ const chatInput = document.getElementById('chatInput');
 const sendBtn = document.getElementById('sendMessageBtn');
 const messagesDiv = document.getElementById('chatMessages');
 const indicator = document.getElementById('chatLoadingIndicator');
+
+function displayIndicator() {
+  indicator.classList.remove('hidden');
+}
+
+function hideIndicator() {
+  indicator.classList.add('hidden');
+}
+
+function displayBotReply(text) {
+  requestIdleCallback(() => addMessage('Bakteri', text, 'bacteria'));
+}
 
 function addMessage(sender, text, type) {
   setTimeout(() => {
@@ -27,14 +39,19 @@ async function onUserMessage() {
   addMessage('Sen', msg, 'user');
   chatHistory.push({ sender: 'user', text: msg });
 
-  indicator.classList.remove('hidden');
+  displayIndicator();
+  if (!summarize) {
+    ({ summarize } = await import(/* webpackChunkName:"summarizer" */ '../src/engine/ContextSummarizer.js'));
+    ({ default: CharacterProfile } = await import('../src/engine/CharacterProfile.js'));
+    ({ generateAnswer } = await import('../src/engine/LanguageEngine.js'));
+  }
   const summary = await summarize(chatHistory);
   const profile = new CharacterProfile('Bakteri-2', 'curious');
   const reply = await generateAnswer(msg, summary, profile);
-  indicator.classList.add('hidden');
+  hideIndicator();
 
   chatHistory.push({ sender: 'bacteria', text: reply });
-  addMessage('Bakteri', reply, 'bacteria');
+  displayBotReply(reply);
 }
 
 sendBtn?.addEventListener('click', onUserMessage);

--- a/src/engine/CharacterProfile.js
+++ b/src/engine/CharacterProfile.js
@@ -1,22 +1,50 @@
-export class CharacterProfile {
+/**
+ * Character profile used to apply personality-driven tone to generated text.
+ * Each tone has predefined phrases injected into answers to create lively
+ * conversations.
+ */
+const TONE_PHRASES = {
+  curious: [
+    'Hmm, ilginç!',
+    'Merak ettim!'
+  ],
+  playful: [
+    'Haha!',
+    'Çok eğlenceli.'
+  ],
+  scientific: [
+    'Bilimsel olarak',
+    'Araştırmalara göre'
+  ]
+};
+
+export default class CharacterProfile {
   constructor(id, tone) {
     this.id = id;
     this.tone = tone;
   }
 
-  applyTone(answer) {
-    const phrases = {
-      curious: ['merak ediyorum', 'ilginç değil mi?'],
-      playful: ['haha!', 'çok eğlenceli'],
-      scientific: ['bilimsel olarak', 'araştırmalara göre']
-    }[this.tone] || [];
-
+  /**
+   * Inject 1-2 phrases based on tone into the provided text.
+   * @param {string} text
+   * @returns {string}
+   */
+  applyTone(text) {
+    const pool = TONE_PHRASES[this.tone] || [];
     const count = 1 + Math.floor(Math.random() * 2);
-    let final = answer;
+    let result = text;
     for (let i = 0; i < count; i++) {
-      const phrase = phrases[Math.floor(Math.random() * phrases.length)] || '';
-      final += (phrase ? ' ' + phrase : '');
+      const phrase = pool[Math.floor(Math.random() * pool.length)];
+      if (phrase) result += (result.endsWith('.') ? ' ' : '. ') + phrase;
     }
-    return final.trim();
+    return result;
   }
 }
+
+/**
+ * Example:
+ * @example
+ * const profile = new CharacterProfile('Bakteri-2', 'curious');
+ * console.log(profile.applyTone('Merhaba dunya.'));
+ */
+

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -8,7 +8,7 @@ import express from 'express';
 import http from 'http';
 import api from './api.js';
 import { setupWebsocket } from './websocket.js';
-import { manager } from './simulationService.js';
+import { startBackground, stopBackground } from './simulationService.js';
 
 const app = express();
 app.use(express.json());
@@ -16,6 +16,7 @@ app.use('/', api);
 
 const server = http.createServer(app);
 setupWebsocket(server);
+await startBackground();
 
 const PORT = process.env.PORT || 3000;
 server.listen(PORT, () => {
@@ -24,8 +25,9 @@ server.listen(PORT, () => {
 
 function shutdown() {
   console.log('Shutting down...');
-  manager.stop();
+  stopBackground();
   server.close(() => process.exit(0));
 }
 process.on('SIGINT', shutdown);
 process.on('SIGTERM', shutdown);
+


### PR DESCRIPTION
## Summary
- run continuous simulation in a Node service
- start/stop background loop from the server entry
- create tone-aware `CharacterProfile`
- rework context summarizer and worker
- upgrade language engine with intent extraction and templating
- improve frontend to lazy-load modules and update DOM using `requestIdleCallback`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68541617fb20833287aab903144bad85