### PR TITLE
Add background simulation loops

### DIFF
--- a/src/engine/index.js
+++ b/src/engine/index.js
@@ -1,0 +1,14 @@
+// Bootstrap the lightweight simulation engine in the main thread.
+import SimulationManager from './SimulationManager.js';
+
+const manager = new SimulationManager();
+manager.startBackground();
+
+// Example UI hook - assumes renderBacteriaMessage is defined elsewhere
+manager.events.on('newMessage', ({ from, to, text }) => {
+  if (typeof renderBacteriaMessage === 'function') {
+    renderBacteriaMessage(from, to, text);
+  }
+});
+
+export default manager;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -16,7 +16,9 @@ app.use('/', api);
 
 const server = http.createServer(app);
 setupWebsocket(server);
-await startBackground();
+(async () => {
+  await startBackground();
+})();
 
 const PORT = process.env.PORT || 3000;
 server.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- run ticks and random dialogues in `SimulationManager`
- expose a default instance in `src/engine/index.js`
- start the background service inside server index

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68544df7991083328f3d8244249cae93