### PR TITLE
Add chat interface helpers and UI indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,11 +257,9 @@
             <div id="chatMessages" class="flex-grow bg-gray-700 rounded-md p-3 overflow-y-auto mb-3 smooth-scroll space-y-2 h-64 min-h-[16rem] max-h-[20rem]" style="display: flex; flex-direction: column-reverse;">
                 <!-- Sohbet mesajları buraya eklenecek -->
             </div>
-            <div id="chatLoadingIndicator" class="hidden text-center py-2">
-                <div class="loader"></div>
-                <p class="text-sm text-gray-400">Bakteri düşünüyor...</p>
-            </div>
-            <div class="flex">
+            <div id="thinkingIndicator" class="hidden text-center py-2">Düşünüyor...</div>
+            <div class="flex items-center space-x-2">
+                <span id="serial-number">#1</span>
                 <input type="text" id="chatInput" class="flex-grow bg-gray-600 text-gray-200 border border-gray-500 rounded-l-lg p-2 focus:ring-teal-500 focus:border-teal-500 outline-none" placeholder="Mesajınızı yazın..." role="textbox" aria-label="Mesajınızı yazın" tabindex="0" disabled>
                 <button id="sendMessageBtn" class="bg-teal-500 hover:bg-teal-600 text-white font-bold p-2 rounded-r-lg transition duration-150 ease-in-out" role="button" aria-label="Gönder" tabindex="0" disabled>Gönder</button>
             </div>
@@ -8891,5 +8889,6 @@ Conscious bacteria: ${bacteriaList.filter(b => (b.consciousness || b.consciousne
         document.addEventListener('DOMContentLoaded', mainInitialize);
 
     </script>
+    <script type="module" src="./public/main.js"></script>
 </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,52 @@
+import { summarize } from '../src/engine/ContextSummarizer.js';
+import { CharacterProfile } from '../src/engine/CharacterProfile.js';
+import { generateAnswer } from '../src/engine/LanguageEngine.js';
+
+let chatHistory = [];
+let counter = 1;
+
+const chatInput = document.getElementById('chatInput');
+const sendBtn = document.getElementById('sendMessageBtn');
+const indicator = document.getElementById('thinkingIndicator');
+const serial = document.getElementById('serial-number');
+
+// Default persona
+let selectedId = 'Bakteri-2';
+let selectedTone = 'curious';
+
+function renderBotReply(text) {
+  const div = document.createElement('div');
+  div.className = 'bot-reply';
+  div.textContent = text;
+  document.getElementById('chatMessages').appendChild(div);
+}
+
+sendBtn.addEventListener('click', async () => {
+  const userMsg = chatInput.value.trim();
+  if (!userMsg) return;
+
+  // 1. Kullanıcı mesajını kaydet ve serial numarayı güncelle
+  chatHistory.push({ sender: 'user', text: userMsg });
+  serial.textContent = `#${++counter}`;
+
+  // 2. UI: thinking göstergesi
+  indicator.style.display = 'inline-block';
+
+  // 3. Context özetle
+  const context = await summarize(chatHistory);
+
+  // 4. Karakter profili oluştur
+  const profile = new CharacterProfile(selectedId, selectedTone);
+
+  // 5. Cevabı üret
+  const reply = await generateAnswer(userMsg, context, profile);
+
+  // 6. UI: thinking kapat, cevap göster
+  indicator.style.display = 'none';
+  renderBotReply(reply);
+
+  // 7. Sohbet geçmişine ekle
+  chatHistory.push({ sender: selectedId, text: reply });
+
+  chatInput.value = '';
+});


### PR DESCRIPTION
## Summary
- create `public/main.js` for chat handling
- show serial numbers and thinking indicator in chat UI
- load the new public script from `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685463e1e4bc8332ac957dccbaca78d5