### PR TITLE
Add background simulation service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "9.6.2",
       "license": "MIT",
       "dependencies": {
-        "express": "^4.18.2",
+        "events": "^3.3.0",
+        "express": "^4.21.2",
         "socket.io": "^4.7.2"
       },
       "devDependencies": {
@@ -2951,6 +2952,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/execa": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint:fix": "eslint src/**/*.js --fix",
     "validate:config": "node scripts/validateConfig.js",
     "build:production": "NODE_ENV=production npm run validate:config && npm run test",
-    "dev": "npx serve . --live"
+    "dev": "npx serve . --live",
+    "start-server": "node src/server/index.js"
   },
   "jest": {
     "globals": {
@@ -56,21 +57,36 @@
       "sourceType": "module"
     },
     "rules": {
-      "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_"
+        }
+      ],
       "no-undef": "error",
-      "no-console": ["warn", { "allow": ["warn", "error", "info"] }],
+      "no-console": [
+        "warn",
+        {
+          "allow": [
+            "warn",
+            "error",
+            "info"
+          ]
+        }
+      ],
       "prefer-const": "error",
       "no-var": "error"
     }
   },
   "devDependencies": {
+    "eslint": "^8.0.0",
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^29.0.0",
-    "eslint": "^8.0.0",
     "serve": "^14.0.0"
   },
   "dependencies": {
-    "express": "^4.18.2",
+    "events": "^3.3.0",
+    "express": "^4.21.2",
     "socket.io": "^4.7.2"
   },
   "engines": {
@@ -88,4 +104,4 @@
   ],
   "author": "mnBac Team",
   "license": "MIT"
-} 
+}


### PR DESCRIPTION
## Summary
- add background simulation event loop
- expose new Node.js entry in `src/server/index.js`
- include start script and runtime deps

## Testing
- `npm test`
- `timeout 10 node src/server/index.js > /tmp/server.log 2>&1`

------
https://chatgpt.com/codex/tasks/task_e_68547d1e17c08332b532cb26c235b2f8