### PR TITLE
Add background simulation service

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 /**
  * @file index.js
- * @description
- * Boots the background simulation service and handles graceful shutdown.
+ * @description Boots the background simulation service with graceful shutdown.
  */
 
 import http from 'http';
@@ -12,18 +11,16 @@ import simulationEvents, { startBackgroundSimulation } from './simulationService
 const app = express();
 const server = http.createServer(app);
 
-// Start the simulation in the background
+// Start simulation
 startBackgroundSimulation();
-simulationEvents.on('tick', state => console.log('tick', state.population.length));
-simulationEvents.on('dialogue', d => console.log('dialogue', d));
 
 // Optional: expose a health endpoint
-app.get('/health', (req, res) => res.send({ status: 'running' }));
+app.get('/health', (req, res) => res.json({ status: 'running' }));
 
 // Start HTTP server
 const PORT = process.env.PORT || 4000;
 server.listen(PORT, () => {
-  console.log(`Background simulation service listening on port ${PORT}`);
+  console.log(`Simulation service listening on port ${PORT}`);
 });
 
 // Handle graceful shutdown
@@ -31,7 +28,7 @@ function shutdown() {
   console.log('Shutting down simulation service...');
   simulationEvents.emit('stop');
   server.close(() => {
-    console.log('HTTP server closed. Exiting process.');
+    console.log('HTTP server closed. Exiting.');
     process.exit(0);
   });
 }

--- a/src/server/simulationService.js
+++ b/src/server/simulationService.js
@@ -1,7 +1,6 @@
 /**
  * @module simulationService
- * @description
- * Runs the bacterial simulation in the background at 60 FPS and emits autonomous dialogues.
+ * @description Runs the bacterial simulation continuously at 60 FPS and emits autonomous dialogues.
  */
 
 import { EventEmitter } from 'events';
@@ -11,7 +10,7 @@ const simulationEvents = new EventEmitter();
 
 /**
  * Starts the background simulation loop and autonomous dialogues.
- * @returns {EventEmitter} An EventEmitter that emits 'tick' and 'dialogue' events.
+ * @returns {EventEmitter} Emits 'tick' (manager state) and 'dialogue' ({from, to, message}).
  */
 export function startBackgroundSimulation() {
   const manager = new SimulationManager();


### PR DESCRIPTION
## Summary
- add continuous background simulation service
- boot service with graceful shutdown

## Testing
- `npm test`
- `npm run start-server` and verify `/health` endpoint

------
https://chatgpt.com/codex/tasks/task_e_68553a43960083328b68464994c5034e