### PR TITLE
Add REST API for simulation state and logs

### DIFF
--- a/src/server/api.js
+++ b/src/server/api.js
@@ -1,32 +1,62 @@
 import { Router } from 'express';
-import { manager } from './simulationService.js';
-import { getLogs } from './logger.js';
+import simulationEvents from './simulationService.js';
+import { getAllLogs } from './logger.js';
 
-/** Express router exposing simulation API */
+/**
+ * Express router exposing simulation state and analytics logs.
+ * `/state` responses are cached briefly for performance.
+ * @module api
+ */
 const router = Router();
 
 let cachedState = null;
 let cachedAt = 0;
 
 /**
- * GET /state - returns simulation state. Result is cached for a short duration
- * to avoid expensive state assembly when called repeatedly.
+ * GET /state - Retrieve the latest simulation state.
+ * Emits a `requestState` event and waits for the corresponding `state` event.
+ * Results are cached for 100ms to avoid unnecessary work.
  */
-router.get('/state', (req, res) => {
-  const now = Date.now();
-  if (!cachedState || now - cachedAt > 100) {
-    cachedState = manager.getState();
+router.get('/state', async (req, res, next) => {
+  try {
+    const now = Date.now();
+    if (cachedState && now - cachedAt < 100) {
+      return res.json(cachedState);
+    }
+
+    const state = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        simulationEvents.off('state', onState);
+        reject(new Error('Timeout retrieving state'));
+      }, 2000);
+
+      function onState(s) {
+        clearTimeout(timer);
+        resolve(s);
+      }
+
+      simulationEvents.once('state', onState);
+      simulationEvents.emit('requestState');
+    });
+
+    cachedState = state;
     cachedAt = now;
+    res.json(state);
+  } catch (err) {
+    next(err);
   }
-  res.json(cachedState);
 });
 
 /**
- * GET /logs - return parsed experiment logs
+ * GET /logs - Retrieve all experiment logs.
  */
-router.get('/logs', async (req, res) => {
-  const logs = await getLogs();
-  res.json(logs);
+router.get('/logs', async (req, res, next) => {
+  try {
+    const logs = await getAllLogs();
+    res.json(logs);
+  } catch (err) {
+    next(err);
+  }
 });
 
 export default router;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,29 +1,28 @@
 #!/usr/bin/env node
 /**
  * @file index.js
- * @description
- * Boots the background simulation service and handles graceful shutdown.
+ * @description Boots the background simulation service with graceful shutdown.
  */
 
 import http from 'http';
 import express from 'express';
 import simulationEvents, { startBackgroundSimulation } from './simulationService.js';
+import apiRouter from './api.js';
 
 const app = express();
 const server = http.createServer(app);
 
-// Start the simulation in the background
+// Start simulation
 startBackgroundSimulation();
-simulationEvents.on('tick', state => console.log('tick', state.population.length));
-simulationEvents.on('dialogue', d => console.log('dialogue', d));
 
 // Optional: expose a health endpoint
-app.get('/health', (req, res) => res.send({ status: 'running' }));
+app.use('/api', apiRouter);
+app.get('/health', (req, res) => res.json({ status: 'running' }));
 
 // Start HTTP server
 const PORT = process.env.PORT || 4000;
 server.listen(PORT, () => {
-  console.log(`Background simulation service listening on port ${PORT}`);
+  console.log(`Simulation service listening on port ${PORT}`);
 });
 
 // Handle graceful shutdown
@@ -31,7 +30,7 @@ function shutdown() {
   console.log('Shutting down simulation service...');
   simulationEvents.emit('stop');
   server.close(() => {
-    console.log('HTTP server closed. Exiting process.');
+    console.log('HTTP server closed. Exiting.');
     process.exit(0);
   });
 }

--- a/src/server/simulationService.js
+++ b/src/server/simulationService.js
@@ -1,20 +1,28 @@
 /**
  * @module simulationService
- * @description
- * Runs the bacterial simulation in the background at 60 FPS and emits autonomous dialogues.
+ * @description Runs the bacterial simulation continuously at 60 FPS and emits
+ * autonomous dialogues. Listens for `requestState` and responds with a `state`
+ * event containing the current simulation snapshot.
  */
 
 import { EventEmitter } from 'events';
 import SimulationManager from '../engine/SimulationManager.js';
 
 const simulationEvents = new EventEmitter();
+let manager = null;
 
 /**
  * Starts the background simulation loop and autonomous dialogues.
- * @returns {EventEmitter} An EventEmitter that emits 'tick' and 'dialogue' events.
- */
+ * @returns {EventEmitter} Emits 'tick', 'dialogue' and responds to
+ * `requestState` with a `state` event.
+*/
 export function startBackgroundSimulation() {
-  const manager = new SimulationManager();
+  manager = new SimulationManager();
+
+  const handleRequestState = () => {
+    simulationEvents.emit('state', manager.getState());
+  };
+  simulationEvents.on('requestState', handleRequestState);
 
   // 60 FPS simulation tick loop
   const tickInterval = setInterval(() => {
@@ -34,6 +42,7 @@ export function startBackgroundSimulation() {
   simulationEvents.once('stop', () => {
     clearInterval(tickInterval);
     clearInterval(dialogueInterval);
+    simulationEvents.off('requestState', handleRequestState);
   });
 
   return simulationEvents;


### PR DESCRIPTION
## Summary
- expose a new API router providing `/state` and `/logs`
- handle state requests via events in the simulation service
- mount the API router in the server index

## Testing
- `npm run lint`
- `npm test`
- `npm run start-server` and hit `/health`, `/api/state`, and `/api/logs`


------
https://chatgpt.com/codex/tasks/task_e_68553a43960083328b68464994c5034e