### PR TITLE
Add MLflow tracking and Docker CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,23 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
       - run: npm ci
       - run: npm run lint
       - run: npm test
+      - run: pytest -q
+      - name: Build simulation Docker image
+        run: docker build -f Dockerfile.sim -t neo-sim .
+      - name: Run simulation container
+        run: docker run --rm -v ${{ github.workspace }}/mlruns:/mlruns neo-sim
+      - name: Upload MLflow logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: mlruns
+          path: mlruns
+      - name: MLflow UI Info
+        run: echo "Download the 'mlruns' artifact and run 'mlflow ui --backend-store-uri mlruns' to view experiment results."

--- a/Dockerfile.sim
+++ b/Dockerfile.sim
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV MLFLOW_TRACKING_URI=/mlruns
+CMD ["python", "run_experiments.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+mlflow
+pytest

--- a/run_experiments.py
+++ b/run_experiments.py
@@ -2,8 +2,8 @@ import json
 import os
 import random
 import numpy as np
-import tensorflow as tf
 from datetime import datetime
+import mlflow
 
 
 def load_params(path):
@@ -13,7 +13,6 @@ def load_params(path):
 def set_global_seed(seed):
     random.seed(seed)
     np.random.seed(seed)
-    tf.random.set_seed(seed)
 
 def simulate(params, seed):
     """Dummy simulation that uses RNG to generate results."""
@@ -35,7 +34,12 @@ def save_results(results, out_dir):
     return path
 
 
-def run(control_config, treatment_config, seed=42):
+def run(control_config, treatment_config, seed=42, model_version="1.0"):
+    """Run paired control/treatment simulations and log with MLflow."""
+
+    mlflow.set_tracking_uri(os.getenv("MLFLOW_TRACKING_URI", "file:/mlruns"))
+    mlflow.set_experiment("NeoMag-Sim")
+
     ctrl_params = load_params(control_config)
     trt_params = load_params(treatment_config)
 
@@ -43,12 +47,26 @@ def run(control_config, treatment_config, seed=42):
     ctrl_out = os.path.join('outputs', f'control_{timestamp}')
     trt_out = os.path.join('outputs', f'treatment_{timestamp}')
 
-    ctrl_results = simulate(ctrl_params, seed)
-    ctrl_path = save_results(ctrl_results, ctrl_out)
+    with mlflow.start_run() as run_ctx:
+        mlflow.log_params({f'control_{k}': v for k, v in ctrl_params.items()})
+        mlflow.log_params({f'treatment_{k}': v for k, v in trt_params.items()})
+        mlflow.log_param("seed", seed)
+        mlflow.log_param("model_version", model_version)
 
-    # treatment uses same seed for identical start
-    trt_results = simulate(trt_params, seed)
-    trt_path = save_results(trt_results, trt_out)
+        ctrl_results = simulate(ctrl_params, seed)
+        ctrl_path = save_results(ctrl_results, ctrl_out)
+        mlflow.log_metric('control_final_population',
+                          ctrl_results['data'][-1]['population'])
+        mlflow.log_artifacts(ctrl_out, artifact_path='control')
+
+        # treatment uses same seed for identical start
+        trt_results = simulate(trt_params, seed)
+        trt_path = save_results(trt_results, trt_out)
+        mlflow.log_metric('treatment_final_population',
+                          trt_results['data'][-1]['population'])
+        mlflow.log_artifacts(trt_out, artifact_path='treatment')
+
+        print(f"MLflow run completed: {mlflow.get_tracking_uri()}/#/experiments/{run_ctx.info.experiment_id}/runs/{run_ctx.info.run_id}")
 
     print(f'Control results saved to {ctrl_path}')
     print(f'Treatment results saved to {trt_path}')

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,27 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from run_experiments import simulate, load_params, run
+
+def test_simulate_length():
+    params = load_params('experiment_configs/control.json')
+    results = simulate(params, seed=0)
+    assert len(results['data']) == params['steps']
+
+def test_population_int():
+    params = load_params('experiment_configs/control.json')
+    results = simulate(params, seed=0)
+    assert all(isinstance(step['population'], int) for step in results['data'])
+
+from pathlib import Path
+
+
+def test_run_creates_mlruns(tmp_path):
+    os.chdir(tmp_path)
+    base = Path(__file__).resolve().parents[1]
+    os.environ['MLFLOW_TRACKING_URI'] = f'file:{tmp_path / "mlruns"}'
+    run(str(base / 'experiment_configs' / 'control.json'),
+        str(base / 'experiment_configs' / 'treatment.json'), seed=1)
+    assert (tmp_path / 'mlruns').exists()


### PR DESCRIPTION
## Summary
- log experiments with MLflow in `run_experiments.py`
- add simulation tests for Python code
- create Python Docker image for running experiments
- extend CI to build the Docker image, run Python and Node tests, run a simulation in Docker, and upload MLflow artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560298b1d88332b7b808e08de0c8b6