### PR TITLE
Add simulation metrics dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,10 @@
         </div>
     </main>
 
-    <!-- Footer -->
+    <div class="container mx-auto my-4">
+        <canvas id="energyChart" class="w-full h-48 mb-4"></canvas>
+        <canvas id="metricsChart" class="w-full h-48"></canvas>
+    </div>
     <footer class="bg-gray-800 text-center p-3 text-sm text-gray-500">
         NeoMag v8.0.0 - Simülasyon Arayüzü Prototipi
     </footer>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "9.6.2",
       "license": "MIT",
       "dependencies": {
+        "chart.js": "^4.4.0",
         "events": "^3.3.0",
         "express": "^4.21.2",
         "socket.io": "^4.7.2"
@@ -1096,6 +1097,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2008,6 +2015,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.0.tgz",
+      "integrity": "sha512-vQEj6d+z0dcsKLlQvbKIMYFHd3t8W/7L2vfJIbYcfyPcRx92CsHqECpueN8qVGNlKyDcr5wBrYAYKnfu/9Q1hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=7"
       }
     },
     "node_modules/ci-info": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "serve": "^14.0.0"
   },
   "dependencies": {
+    "chart.js": "^4.4.0",
     "events": "^3.3.0",
     "express": "^4.21.2",
     "socket.io": "^4.7.2"

--- a/public/main.js
+++ b/public/main.js
@@ -4,9 +4,122 @@
 import { summarize } from '../src/engine/ContextSummarizer.js';
 import { CharacterProfile } from '../src/engine/CharacterProfile.js';
 import { generateAnswer } from '../src/engine/LanguageEngine.js';
+import SimulationManager from '../src/engine/SimulationManager.js';
+import { wordSuccessTracker } from '../src/engine/WordSuccessTracker.ts';
+import Chart from 'chart.js/auto';
 
 let chatHistory = [];
 let counter = 1;
+
+// Setup simulation manager
+const manager = new SimulationManager(5, 1);
+manager.startBackground();
+
+// Move start button into header toolbar and hook listener
+const startBtn = document.getElementById('startSimulationBtn');
+const toolbar = document.querySelector('header .flex.gap-2');
+if (startBtn && toolbar) {
+  toolbar.appendChild(startBtn);
+  startBtn.addEventListener('click', () => {
+    if (manager.running) {
+      manager.stopBackground();
+      startBtn.textContent = '▶️ Simülasyonu Başlat';
+    } else {
+      manager.startBackground();
+      startBtn.textContent = '⏹️ Durdur';
+    }
+  });
+}
+
+// Load persisted vocabulary
+const savedWords = wordSuccessTracker.loadBacteriaWords();
+manager.bacteria.forEach(b => {
+  if (savedWords[b.id]) {
+    savedWords[b.id].forEach(w => b.vocabulary.add(w));
+  }
+});
+
+window.addEventListener('beforeunload', () => {
+  wordSuccessTracker.saveBacteriaWords(manager.bacteria);
+});
+
+// Chart.js metrics setup
+const energyCtx = document.getElementById('energyChart').getContext('2d');
+const energyChart = new Chart(energyCtx, {
+  type: 'pie',
+  data: {
+    labels: ['High', 'Medium', 'Low'],
+    datasets: [{
+      data: [0, 0, 0],
+      backgroundColor: ['#16a34a', '#facc15', '#dc2626']
+    }]
+  },
+  options: { responsive: true }
+});
+
+const metricsCtx = document.getElementById('metricsChart').getContext('2d');
+const metricsChart = new Chart(metricsCtx, {
+  type: 'bar',
+  data: {
+    labels: [],
+    datasets: [
+      {
+        label: 'Learned Words',
+        data: [],
+        backgroundColor: '#3b82f6',
+        borderWidth: 1
+      },
+      {
+        label: 'Avg Response (ms)',
+        data: [],
+        type: 'line',
+        borderColor: '#f97316',
+        fill: false,
+        yAxisID: 'y1'
+      }
+    ]
+  },
+  options: {
+    responsive: true,
+    scales: { y1: { position: 'right', beginAtZero: true } }
+  }
+});
+
+let wordCountData = [];
+let responseTimeData = [];
+let lastDialogue = performance.now();
+
+function updateCharts() {
+  const state = manager.getState();
+  const energies = state.population.map(p => p.energy);
+  const high = energies.filter(e => e > 0.66).length;
+  const mid = energies.filter(e => e <= 0.66 && e >= 0.33).length;
+  const low = energies.filter(e => e < 0.33).length;
+  energyChart.data.datasets[0].data = [high, mid, low];
+  energyChart.update();
+
+  const totalWords = state.population.reduce((s, p) => s + p.vocabularySize, 0);
+  const avgResp = responseTimeData.length
+    ? responseTimeData.reduce((a, b) => a + b, 0) / responseTimeData.length
+    : 0;
+  metricsChart.data.labels.push('');
+  metricsChart.data.datasets[0].data.push(totalWords);
+  metricsChart.data.datasets[1].data.push(avgResp.toFixed(2));
+  if (metricsChart.data.labels.length > 20) {
+    metricsChart.data.labels.shift();
+    metricsChart.data.datasets.forEach(d => d.data.shift());
+  }
+  metricsChart.update();
+}
+
+manager.events.on('tick', updateCharts);
+manager.events.on('newMessage', () => {
+  const now = performance.now();
+  responseTimeData.push(now - lastDialogue);
+  if (responseTimeData.length > 20) responseTimeData.shift();
+  lastDialogue = now;
+  wordSuccessTracker.saveBacteriaWords(manager.bacteria);
+});
 
 const chatInput = document.getElementById('chatInput');
 const sendBtn = document.getElementById('sendMessageBtn');

--- a/src/engine/WordSuccessTracker.ts
+++ b/src/engine/WordSuccessTracker.ts
@@ -309,6 +309,32 @@ export class WordSuccessTracker {
         return totalAvg / this.contextStats.size;
     }
 
+    // Persist each bacterium's vocabulary to localStorage
+    saveBacteriaWords(bacteriaList) {
+        if (typeof localStorage === 'undefined') return;
+        try {
+            const data = {};
+            bacteriaList.forEach(b => {
+                data[b.id] = Array.from(b.vocabulary || []);
+            });
+            localStorage.setItem('mnBac_words', JSON.stringify(data));
+        } catch (err) {
+            console.error('Failed to save words', err);
+        }
+    }
+
+    // Load vocabulary map from localStorage
+    loadBacteriaWords() {
+        if (typeof localStorage === 'undefined') return {};
+        try {
+            const raw = localStorage.getItem('mnBac_words');
+            return raw ? JSON.parse(raw) : {};
+        } catch (err) {
+            console.error('Failed to load words', err);
+            return {};
+        }
+    }
+
     // Export data (debugging/analytics için)
     exportData() {
         return {


### PR DESCRIPTION
## Summary
- integrate Chart.js and energy/word metrics in the demo page
- persist learned vocabulary between sessions
- expose bacteria energy state from the engine simulation
- move the start button into the header toolbar on load
- add energy & metrics canvases under the canvas

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685613b03b2483328ae11142b6c0eaf6