### PR TITLE
Implement background simulation service

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,29 +1,20 @@
 #!/usr/bin/env node
 /**
  * @file index.js
- * @description Boots the background simulation service with graceful shutdown.
+ * @description Express server that runs the background simulation and exposes a
+ * simple health endpoint. Handles graceful shutdown on termination signals.
  */
 
-import http from 'http';
 import express from 'express';
 import simulationEvents, { startBackgroundSimulation } from './simulationService.js';
-import apiRouter from './api.js';
-import { attachWebsocket } from './websocket.js';
 
 const app = express();
-const server = http.createServer(app);
-attachWebsocket(server);
-
-// Start simulation
-startBackgroundSimulation();
-
-// Optional: expose a health endpoint
-app.use('/api', apiRouter);
 app.get('/health', (req, res) => res.json({ status: 'running' }));
 
-// Start HTTP server
+startBackgroundSimulation();
+
 const PORT = process.env.PORT || 4000;
-server.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`Simulation service listening on port ${PORT}`);
 });
 


### PR DESCRIPTION
## Summary
- simplify background simulation service
- add Express server with health endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856656706308332859bad94cdc9ee15