### PR TITLE
Add population management controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,6 +199,7 @@
         <button id="startSimulationBtn" data-action="start-simulation" class="bg-green-600 hover:bg-green-700 px-6 py-3 rounded-lg text-lg font-bold" role="button" aria-label="Simülasyonu Başlat" tabindex="0">
             ▶️ Simülasyonu Başlat
         </button>
+        <button id="cull10Percent" class="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded text-sm transition ml-2">Cull 10% Population</button>
     </div>
 
     <!-- Main Content -->
@@ -239,6 +240,7 @@
                     <p><strong>Dil Aşaması:</strong> <span id="bacteriaLanguageStage" class="text-gray-300"></span></p>
                     <p><strong>Kelime Haznesi:</strong> <span id="bacteriaVocabulary" class="text-gray-300 break-all"></span></p>
                 </div>
+                <button id="deleteBacterium" class="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded text-sm transition mt-2">Delete Bacterium</button>
             </div>
         </div>
 

--- a/public/main.js
+++ b/public/main.js
@@ -31,6 +31,19 @@ if (startBtn && toolbar) {
   });
 }
 
+document.getElementById('deleteBacterium').addEventListener('click', () => {
+  const selectedId = getSelectedBacteriumId();
+  manager.removeBacterium(selectedId);
+  if (typeof renderCanvas === 'function') renderCanvas();
+  if (typeof updateCharts === 'function') updateCharts();
+});
+
+document.getElementById('cull10Percent').addEventListener('click', () => {
+  manager.cullPercentage(10);
+  if (typeof renderCanvas === 'function') renderCanvas();
+  if (typeof updateCharts === 'function') updateCharts();
+});
+
 // Load persisted vocabulary
 const savedWords = wordSuccessTracker.loadBacteriaWords();
 manager.bacteria.forEach(b => {
@@ -129,6 +142,10 @@ const serial = document.getElementById('serial-number');
 // Default persona
 let selectedId = 'Bakteri-2';
 let selectedTone = 'curious';
+
+function getSelectedBacteriumId() {
+  return selectedId;
+}
 
 function idle(cb) {
   if ('requestIdleCallback' in window) {

--- a/src/managers/SimulationManager.js
+++ b/src/managers/SimulationManager.js
@@ -586,6 +586,26 @@ export class SimulationManager {
         chatMessages.scrollTop = chatMessages.scrollHeight;
     }
 
+    /**
+     * Remove one bacterium by id.
+     * @param {string} id
+     */
+    removeBacterium(id) {
+        this.bacteriaPopulation = this.bacteriaPopulation.filter(b => b.id !== id);
+    }
+
+    /**
+     * Randomly remove a percentage of the population.
+     * @param {number} percent  // e.g. 10 for 10%
+     */
+    cullPercentage(percent) {
+        const countToCull = Math.floor(this.bacteriaPopulation.length * percent / 100);
+        for (let i = 0; i < countToCull; i++) {
+            const idx = Math.floor(Math.random() * this.bacteriaPopulation.length);
+            this.bacteriaPopulation.splice(idx, 1);
+        }
+    }
+
     // Simülasyonu başlat
     start() {
         if (!this.initialized) {


### PR DESCRIPTION
## Summary
- add Cull 10% Population button to quick controls
- add Delete Bacterium button under bacteria details
- support removing bacteria in SimulationManager
- bind new toolbar actions in main.js

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68566f0276c08332aee17ea1855e77ee