### PR TITLE
Add background simulation service

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 /**
  * @file index.js
- * @description Express server that runs the background simulation and exposes a
- * simple health endpoint. Handles graceful shutdown on termination signals.
+ * @description
+ * Entry point for the Node.js service hosting the background simulation.
+ * Starts an Express HTTP server, exposes a basic health check and runs the
+ * simulation loop in the background. The process listens for termination
+ * signals in order to stop the simulation and close the server cleanly.
  */
 
 import express from 'express';
+import http from 'http';
 import simulationEvents, { startBackgroundSimulation } from './simulationService.js';
 
 const app = express();
@@ -13,8 +17,9 @@ app.get('/health', (req, res) => res.json({ status: 'running' }));
 
 startBackgroundSimulation();
 
-const PORT = process.env.PORT || 4000;
-const server = app.listen(PORT, () => {
+const PORT = 4000;
+const server = http.createServer(app);
+server.listen(PORT, () => {
   console.log(`Simulation service listening on port ${PORT}`);
 });
 

--- a/src/server/simulationService.js
+++ b/src/server/simulationService.js
@@ -1,19 +1,36 @@
 /**
  * @module simulationService
- * @description Background service that drives the simulation at 60 FPS and
- * periodically triggers bacteria dialogue. Emits `tick` and `dialogue` events
- * that other modules can subscribe to.
+ * @description
+ * Provides a small event-based API that runs the server-side simulation in the
+ * background. The service ticks the {@link SimulationManager} 60 times per
+ * second and triggers autonomous dialogues between random bacteria every four
+ * seconds. Consumers can listen to `tick` and `dialogue` events to react to
+ * state changes.
  */
 
 import { EventEmitter } from 'events';
 import SimulationManager from '../engine/SimulationManager.js';
 
+/**
+ * Event emitter used to broadcast simulation updates.
+ *
+ * @type {EventEmitter}
+ */
 const simulationEvents = new EventEmitter();
+
+// local reference to the simulation manager instance
 let manager = null;
 
 /**
  * Start the background simulation loop and dialogue cycle.
- * @returns {EventEmitter} Event emitter publishing `tick` and `dialogue` events.
+ *
+ * The function creates a {@link SimulationManager} instance, schedules a tick
+ * loop running at 60 FPS and a dialogue loop every four seconds. Each tick
+ * emits the current simulation state via the `tick` event. Dialogues emit a
+ * `dialogue` event describing the interaction. A `stop` event listener is
+ * attached so callers can gracefully terminate the service.
+ *
+ * @returns {EventEmitter} emitter broadcasting simulation events
  */
 export function startBackgroundSimulation() {
   manager = new SimulationManager();


### PR DESCRIPTION
## Summary
- add background simulation event service
- launch simulation server with Express on port 4000

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685671f06cdc833282fc3686f1673cb3