### PR TITLE
Add REST API router

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -11,8 +11,12 @@
 import express from 'express';
 import http from 'http';
 import simulationEvents, { startBackgroundSimulation } from './simulationService.js';
+import apiRouter from './api.js';
 
 const app = express();
+
+// Mount REST API
+app.use('/api', apiRouter);
 app.get('/health', (req, res) => res.json({ status: 'running' }));
 
 startBackgroundSimulation();

--- a/src/server/simulationService.js
+++ b/src/server/simulationService.js
@@ -35,6 +35,13 @@ let manager = null;
 export function startBackgroundSimulation() {
   manager = new SimulationManager();
 
+  // Provide current state on demand
+  simulationEvents.on('requestState', () => {
+    if (manager) {
+      simulationEvents.emit('state', manager.getState());
+    }
+  });
+
   // 60 FPS simulation tick loop
   const tickInterval = setInterval(() => {
     manager.tick();


### PR DESCRIPTION
## Summary
- implement Express router with `/state` and `/logs`
- expose `/api` routes from server
- reply to `requestState` events with current state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856768d78b48332a99d4a9ebc98bff6