### PR TITLE
Add websocket broadcasting

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -12,6 +12,7 @@ import express from 'express';
 import http from 'http';
 import simulationEvents, { startBackgroundSimulation } from './simulationService.js';
 import apiRouter from './api.js';
+import { attachWebsocket } from './websocket.js';
 
 const app = express();
 
@@ -23,6 +24,7 @@ startBackgroundSimulation();
 
 const PORT = 4000;
 const server = http.createServer(app);
+attachWebsocket(server);
 server.listen(PORT, () => {
   console.log(`Simulation service listening on port ${PORT}`);
 });

--- a/src/server/websocket.js
+++ b/src/server/websocket.js
@@ -4,11 +4,10 @@ import simulationEvents from './simulationService.js';
 /**
  * Attach a Socket.IO server to an existing HTTP server and broadcast
  * simulation updates in real time. Clients receive dialogue messages
- * and periodic tick events. Only the changed state is pushed on each
- * tick to reduce bandwidth usage compared to sending the full state.
+ * and periodic tick events.
  *
  * @param {import('http').Server} httpServer - Node HTTP server
- * @returns {Server} The created Socket.IO instance
+ * @returns {void}
  */
 export function attachWebsocket(httpServer) {
   const io = new Server(httpServer);
@@ -24,6 +23,4 @@ export function attachWebsocket(httpServer) {
   simulationEvents.on('tick', state => {
     io.emit('simulationTick', state);
   });
-
-  return io;
 }


### PR DESCRIPTION
## Summary
- broadcast simulation events via Socket.IO
- wire up websocket server in HTTP service

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685679ad615883328efa3f00e573529f