### PR TITLE
Add CharacterProfile tone injection

### DIFF
--- a/src/engine/CharacterProfile.js
+++ b/src/engine/CharacterProfile.js
@@ -1,62 +1,43 @@
 /**
- * CharacterProfile injects short tone phrases into replies.
+ * Adds short personality phrases to generated text.
  *
- * Each tone is mapped to a set of phrases held in {@link CharacterProfile.tonePhrases}.
- * The {@link CharacterProfile#applyTone} method randomly places one of these phrases
- * at the beginning or end of the provided text. Such small variations help break
- * monotonous responses and make the conversation feel more engaging.
+ * Each profile stores an identifier and a communication tone. The tone
+ * determines which phrase pool will be used by {@link CharacterProfile#applyTone}
+ * when decorating output text.
  */
 
 export class CharacterProfile {
   /**
-   * Known tone phrases used when injecting personality.
+   * Mapping of available tones to example phrases.
    * @type {{ [key in 'curious'|'playful'|'scientific']: string[] }}
    */
-  // `tonePhrases` is attached after the class definition to stay
-  // compatible with older ECMAScript versions used in lint rules.
+  static tonePhrases = {
+    curious: ['Hmm, ilginç!', 'Merak ettim doğrusu.'],
+    playful: ['Hoho, ne eğlenceli!', 'Buna bayıldım!'],
+    scientific: ['Veriler gösteriyor ki…', 'Bilimsel açıdan bakacak olursak…']
+  };
 
+  /**
+   * Create a character profile with a unique ID and speaking tone.
+   *
+   * @param {string} id Unique identifier for the character.
+   * @param {'curious'|'playful'|'scientific'} tone Chosen personality tone.
+   */
   constructor(id, tone) {
     this.id = id;
     this.tone = tone;
   }
 
   /**
-   * Add a random phrase before or after the text based on the profile's tone.
+   * Prepend a randomly selected tone phrase to the provided text.
    *
-   * A single phrase is selected from {@link CharacterProfile.tonePhrases} and
-   * then either prepended or appended. This creates subtle variety that keeps
-   * replies feeling lively.
-   *
-   * @param {string} text
-   * @returns {string}
+   * @param {string} text Original text to decorate.
+   * @returns {string} Text with a personality phrase in front.
    */
   applyTone(text) {
     const pool = CharacterProfile.tonePhrases[this.tone] || [];
-    if (!pool.length) return text;
     const phrase = pool[Math.floor(Math.random() * pool.length)];
-    return Math.random() < 0.5
-      ? `${phrase} ${text}`
-      : `${text} ${phrase}`;
+    return `${phrase} ${text}`;
   }
 }
-
-// Static tone phrase definitions attached outside the class so the file
-// remains compatible with ESLint's ES2021 parser settings.
-CharacterProfile.tonePhrases = {
-  curious: [
-    'Hmm, ilginç!',
-    'Merak ettim!',
-    'Nasıl oldu acaba?'
-  ],
-  playful: [
-    'Haha!',
-    'Şaka yapıyorum tabii.',
-    'Bu çok eğlenceli!'
-  ],
-  scientific: [
-    'Bilimsel olarak',
-    'Araştırmalara göre',
-    'Veriler gösteriyor ki'
-  ]
-};
 


### PR DESCRIPTION
## Summary
- simplify `CharacterProfile` implementation
- attach `tonePhrases` statically
- prepend a tone phrase before replies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68567b3a94e483328d11c6499a5f2f9c