### PR TITLE
Fix linting and ensure simulation tests pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
       "eslint:recommended"
     ],
     "parserOptions": {
-      "ecmaVersion": 12,
+      "ecmaVersion": 2022,
       "sourceType": "module"
     },
     "rules": {

--- a/src/engine/CharacterProfile.js
+++ b/src/engine/CharacterProfile.js
@@ -7,15 +7,6 @@
  */
 
 export class CharacterProfile {
-  /**
-   * Mapping of available tones to example phrases.
-   * @type {{ [key in 'curious'|'playful'|'scientific']: string[] }}
-   */
-  static tonePhrases = {
-    curious: ['Hmm, ilginç!', 'Merak ettim doğrusu.'],
-    playful: ['Hoho, ne eğlenceli!', 'Buna bayıldım!'],
-    scientific: ['Veriler gösteriyor ki…', 'Bilimsel açıdan bakacak olursak…']
-  };
 
   /**
    * Create a character profile with a unique ID and speaking tone.
@@ -40,4 +31,11 @@ export class CharacterProfile {
     return `${phrase} ${text}`;
   }
 }
+
+// Initialize static property separately for wider syntax support
+CharacterProfile.tonePhrases = {
+  curious: ['Hmm, ilginç!', 'Merak ettim doğrusu.'],
+  playful: ['Hoho, ne eğlenceli!', 'Buna bayıldım!'],
+  scientific: ['Veriler gösteriyor ki…', 'Bilimsel açıdan bakacak olursak…']
+};
 


### PR DESCRIPTION
## Summary
- update ESLint parser to ES2022
- avoid class field syntax in `CharacterProfile` to keep lint happy

## Testing
- `npm run lint`
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865b6e5b0dc8332a310cf443e7b7ed8